### PR TITLE
Fix SPDX Identifier and Foundry top-level key

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 # Full reference https://github.com/foundry-rs/foundry/tree/master/config
 
-[default]
+[profile.default]
 auto_detect_solc = false
 fuzz_runs = 256
 libs = ["lib"]

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -1,4 +1,4 @@
-/// @dev SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
 /// @dev An EVM interpreter written with testing and debugging in mind. This is usually either HEVM or REVM.


### PR DESCRIPTION
Caught this when flattening the contracts into one. 